### PR TITLE
Add and remove itinerary days from the hotspot modal

### DIFF
--- a/frontend/components/HotspotStats.tsx
+++ b/frontend/components/HotspotStats.tsx
@@ -52,14 +52,6 @@ export default function HotspotStats({ id, speciesTotal, checklistsTotal }: Prop
         )}
         <span className="text-xs">Last Checklist</span>
       </div>
-      <a
-        href={`https://ebird.org/hotspot/${id}`}
-        target="_blank"
-        rel="noreferrer"
-        className="ml-auto self-center opacity-80 transition-opacity hover:opacity-100"
-      >
-        <img src="/ebird.png" alt="View on eBird" width={48} />
-      </a>
     </div>
   );
 }

--- a/frontend/components/HotspotStats.tsx
+++ b/frontend/components/HotspotStats.tsx
@@ -52,6 +52,14 @@ export default function HotspotStats({ id, speciesTotal, checklistsTotal }: Prop
         )}
         <span className="text-xs">Last Checklist</span>
       </div>
+      <a
+        href={`https://ebird.org/hotspot/${id}`}
+        target="_blank"
+        rel="noreferrer"
+        className="ml-auto self-center opacity-80 transition-opacity hover:opacity-100"
+      >
+        <img src="/ebird.png" alt="View on eBird" width={48} />
+      </a>
     </div>
   );
 }

--- a/frontend/components/ItineraryDays.tsx
+++ b/frontend/components/ItineraryDays.tsx
@@ -1,0 +1,175 @@
+import { Day } from "@birdplan/shared";
+import { Badge } from "components/ui/badge";
+import { Button } from "components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "components/ui/dropdown-menu";
+import Icon from "components/Icon";
+import dayjs from "dayjs";
+import { useTrip } from "hooks/useTrip";
+import useTripMutation from "hooks/useTripMutation";
+import { nanoId } from "lib/helpers";
+import { getTripDays } from "lib/itinerary";
+import { cn } from "lib/utils";
+
+type LocationType = "hotspot" | "marker";
+
+type Props = {
+  locationId: string;
+  type: LocationType;
+  className?: string;
+};
+
+export default function ItineraryDays({ locationId, type, className }: Props) {
+  const { trip, canEdit } = useTrip();
+  const days = getTripDays(trip);
+  const dayIds = days.map((it) => it.id);
+  const scheduledDays = days.flatMap((day, index) => {
+    const entry = day.locations?.find((loc) => loc.locationId === locationId);
+    return entry ? [{ day, dayIndex: index, entry }] : [];
+  });
+
+  if (!canEdit || !days.length) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 rounded-xl border border-border/70 bg-muted/50 px-3 py-2",
+        className
+      )}
+    >
+      {scheduledDays.map(({ day, dayIndex, entry }) => (
+        <ScheduledDayChip key={day.id} day={day} dayIndex={dayIndex} entry={entry} />
+      ))}
+      {!scheduledDays.length && <span className="text-[13px] font-medium text-muted-foreground">No scheduled visits</span>}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              size="icon"
+              aria-label={scheduledDays.length ? "Schedule another day" : "Schedule a visit"}
+              className="ml-auto size-7 bg-green-700 shadow-xs hover:bg-green-800"
+            >
+              <Icon name="plus" />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="start" className="min-w-[200px]">
+          {days.map((day, index) => (
+            <ItineraryDayToggle key={day.id} day={day} dayIndex={index} dayIds={dayIds} locationId={locationId} type={type} />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+const formatDayLabel = (startDate: string | undefined, dayIndex: number) =>
+  startDate ? dayjs(startDate).add(dayIndex, "day").format("ddd, MMM D") : `Day ${dayIndex + 1}`;
+
+type ScheduledDayChipProps = {
+  day: Day;
+  dayIndex: number;
+  entry: NonNullable<Day["locations"]>[number];
+};
+
+function ScheduledDayChip({ day, dayIndex, entry }: ScheduledDayChipProps) {
+  const { trip } = useTrip();
+  const label = formatDayLabel(trip?.startDate, dayIndex);
+
+  const removeMutation = useTripMutation<{ id: string }>({
+    url: `/trips/${trip?._id}/itinerary/${day.id}/remove-location`,
+    method: "PATCH",
+    updateCache: (old, input) => ({
+      ...old,
+      itinerary: getTripDays(old).map((it) =>
+        it.id === day.id ? { ...it, locations: it.locations?.filter((loc) => loc.id !== input.id) || [] } : it
+      ),
+    }),
+  });
+
+  return (
+    <Badge variant="outline" className="h-7 gap-1 bg-card pl-2.5 pr-1.5 font-semibold text-green-800">
+      {label}
+      <button
+        type="button"
+        aria-label={`Remove ${label}`}
+        onClick={() => removeMutation.mutate({ id: entry.id })}
+        disabled={removeMutation.isPending}
+        className="flex size-5 shrink-0 items-center justify-center rounded-full text-green-800 transition-colors hover:bg-green-700/10 hover:text-green-950"
+      >
+        <Icon name="xMark" />
+      </button>
+    </Badge>
+  );
+}
+
+type ItineraryDayToggleProps = {
+  day: Day;
+  dayIndex: number;
+  dayIds: string[];
+  locationId: string;
+  type: LocationType;
+};
+
+function ItineraryDayToggle({ day, dayIndex, dayIds, locationId, type }: ItineraryDayToggleProps) {
+  const { trip } = useTrip();
+  const entry = day.locations?.find((loc) => loc.locationId === locationId);
+  const date = trip?.startDate ? dayjs(trip.startDate).add(dayIndex, "day").format("ddd, MMM D") : "";
+
+  const addMutation = useTripMutation<
+    { type: LocationType; locationId: string; id: string; dayIds: string[] },
+    { itinerary: Day[] }
+  >({
+    url: `/trips/${trip?._id}/itinerary/${day.id}/add-location`,
+    method: "POST",
+    updateCache: (old, input) => ({
+      ...old,
+      itinerary: getTripDays(old).map((it) =>
+        it.id === day.id
+          ? {
+              ...it,
+              locations: [...(it.locations || []), { type: input.type, locationId: input.locationId, id: input.id }],
+            }
+          : it
+      ),
+    }),
+    reconcile: (old, response) => ({ ...old, itinerary: response.itinerary }),
+  });
+
+  const removeMutation = useTripMutation<{ id: string }>({
+    url: `/trips/${trip?._id}/itinerary/${day.id}/remove-location`,
+    method: "PATCH",
+    updateCache: (old, input) => ({
+      ...old,
+      itinerary: getTripDays(old).map((it) =>
+        it.id === day.id ? { ...it, locations: it.locations?.filter((loc) => loc.id !== input.id) || [] } : it
+      ),
+    }),
+  });
+
+  const onCheckedChange = (checked: boolean) => {
+    if (checked) {
+      addMutation.mutate({ type, locationId, id: nanoId(6), dayIds });
+    } else if (entry) {
+      removeMutation.mutate({ id: entry.id });
+    }
+  };
+
+  return (
+    <DropdownMenuCheckboxItem
+      checked={!!entry}
+      onCheckedChange={onCheckedChange}
+      closeOnClick
+      disabled={addMutation.isPending || removeMutation.isPending}
+    >
+      <span className="truncate">
+        Day {dayIndex + 1}
+        {date && <span className="text-muted-foreground"> · {date}</span>}
+      </span>
+    </DropdownMenuCheckboxItem>
+  );
+}

--- a/frontend/lib/itinerary.ts
+++ b/frontend/lib/itinerary.ts
@@ -1,4 +1,12 @@
-import { Day } from "@birdplan/shared";
+import { Day, Trip } from "@birdplan/shared";
+import dayjs from "dayjs";
+
+export const getTripDays = (trip?: Trip | null): Day[] => {
+  const persisted = trip?.itinerary || [];
+  if (!trip?.startDate || !trip?.endDate) return persisted;
+  const dayCount = dayjs(trip.endDate).diff(dayjs(trip.startDate), "day") + 1;
+  return Array.from({ length: dayCount }, (_, i) => persisted[i] || { id: `${trip._id}-d${i}`, locations: [] });
+};
 
 export const removeInvalidTravelData = (locations: Day["locations"]) => {
   return (

--- a/frontend/modals/Hotspot.tsx
+++ b/frontend/modals/Hotspot.tsx
@@ -1,22 +1,30 @@
 import React from "react";
 import { Header, Body } from "components/Modal";
-import { HotspotInput, Hotspot as HotspotT, Trip } from "@birdplan/shared";
+import { Day, HotspotInput, Hotspot as HotspotT, Trip } from "@birdplan/shared";
 import { Button } from "components/ui/button";
 import toast from "react-hot-toast";
 import { useTrip } from "hooks/useTrip";
 import DirectionsButton from "components/DirectionsButton";
-import { isRegionEnglish, getMarkerColor } from "lib/helpers";
+import { isRegionEnglish, getMarkerColor, nanoId } from "lib/helpers";
 import RecentSpeciesList from "components/RecentSpeciesList";
 import HotspotStats from "components/HotspotStats";
 import RecentChecklistList from "components/RecentChecklistList";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "components/ui/tabs";
 import InputNotes from "components/InputNotes";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "components/ui/dropdown-menu";
 import KebabMenuTrigger from "components/KebabMenuTrigger";
 import HotspotTargets from "components/HotspotTargets";
 import HotspotFavs from "components/HotspotFavs";
 import Icon from "components/Icon";
 import { useLocation } from "react-router-dom";
+import dayjs from "dayjs";
+import { getTripDays } from "lib/itinerary";
 import useTripMutation from "hooks/useTripMutation";
 import useMutation from "hooks/useMutation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -144,6 +152,10 @@ export default function Hotspot({ hotspot }: Props) {
 
   const canTranslate = isSaved && canEdit && !isRegionEnglish(trip?.region || "");
 
+  const days = getTripDays(trip);
+  const dayIds = days.map((it) => it.id);
+  const scheduledCount = days.filter((day) => day.locations?.some((loc) => loc.locationId === id)).length;
+
   return (
     <>
       <Header>{name}</Header>
@@ -181,6 +193,29 @@ export default function Hotspot({ hotspot }: Props) {
               />
               {isSaved ? "Saved" : "Save"}
             </Button>
+          )}
+          {canEdit && isSaved && !!days.length && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button variant="outline-white" size="sm">
+                    <Icon name="calendar" className="text-gray-400" />
+                    {scheduledCount ? `On ${scheduledCount} ${scheduledCount === 1 ? "day" : "days"}` : "Itinerary"}
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="start" className="min-w-[200px]">
+                {days.map((day, index) => (
+                  <ItineraryDayToggle
+                    key={day.id}
+                    day={day}
+                    dayIndex={index}
+                    dayIds={dayIds}
+                    hotspotId={id}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           <DirectionsButton lat={lat} lng={lng} hotspotId={id} />
           <Button
@@ -249,5 +284,71 @@ export default function Hotspot({ hotspot }: Props) {
         </Tabs>
       </Body>
     </>
+  );
+}
+
+type ItineraryDayToggleProps = {
+  day: Day;
+  dayIndex: number;
+  dayIds: string[];
+  hotspotId: string;
+};
+
+function ItineraryDayToggle({ day, dayIndex, dayIds, hotspotId }: ItineraryDayToggleProps) {
+  const { trip } = useTrip();
+  const entry = day.locations?.find((loc) => loc.locationId === hotspotId);
+  const date = trip?.startDate ? dayjs(trip.startDate).add(dayIndex, "day").format("ddd, MMM D") : "";
+
+  const addMutation = useTripMutation<
+    { type: "hotspot"; locationId: string; id: string; dayIds: string[] },
+    { itinerary: Day[] }
+  >({
+    url: `/trips/${trip?._id}/itinerary/${day.id}/add-location`,
+    method: "POST",
+    updateCache: (old, input) => ({
+      ...old,
+      itinerary: getTripDays(old).map((it) =>
+        it.id === day.id
+          ? {
+              ...it,
+              locations: [...(it.locations || []), { type: input.type, locationId: input.locationId, id: input.id }],
+            }
+          : it
+      ),
+    }),
+    reconcile: (old, response) => ({ ...old, itinerary: response.itinerary }),
+  });
+
+  const removeMutation = useTripMutation<{ id: string }>({
+    url: `/trips/${trip?._id}/itinerary/${day.id}/remove-location`,
+    method: "PATCH",
+    updateCache: (old, input) => ({
+      ...old,
+      itinerary: getTripDays(old).map((it) =>
+        it.id === day.id ? { ...it, locations: it.locations?.filter((loc) => loc.id !== input.id) || [] } : it
+      ),
+    }),
+  });
+
+  const onCheckedChange = (checked: boolean) => {
+    if (checked) {
+      addMutation.mutate({ type: "hotspot", locationId: hotspotId, id: nanoId(6), dayIds });
+    } else if (entry) {
+      removeMutation.mutate({ id: entry.id });
+    }
+  };
+
+  return (
+    <DropdownMenuCheckboxItem
+      checked={!!entry}
+      onCheckedChange={onCheckedChange}
+      closeOnClick={false}
+      disabled={addMutation.isPending || removeMutation.isPending}
+    >
+      <span className="truncate">
+        Day {dayIndex + 1}
+        {date && <span className="text-muted-foreground"> · {date}</span>}
+      </span>
+    </DropdownMenuCheckboxItem>
   );
 }

--- a/frontend/modals/Hotspot.tsx
+++ b/frontend/modals/Hotspot.tsx
@@ -154,7 +154,13 @@ export default function Hotspot({ hotspot }: Props) {
 
   const days = getTripDays(trip);
   const dayIds = days.map((it) => it.id);
-  const scheduledCount = days.filter((day) => day.locations?.some((loc) => loc.locationId === id)).length;
+  const scheduledDayIndexes = days.flatMap((day, index) =>
+    day.locations?.some((loc) => loc.locationId === id) ? [index] : []
+  );
+  const extraDayCount = scheduledDayIndexes.length - 1;
+  const itineraryLabel = scheduledDayIndexes.length
+    ? `${formatDayLabel(trip?.startDate, scheduledDayIndexes[0])}${extraDayCount > 0 ? ` +${extraDayCount}` : ""}`
+    : "Itinerary";
 
   return (
     <>
@@ -198,9 +204,13 @@ export default function Hotspot({ hotspot }: Props) {
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
-                  <Button variant="outline-white" size="sm">
+                  <Button
+                    variant="outline-white"
+                    size="sm"
+                    aria-label={scheduledDayIndexes.length ? `Itinerary: ${itineraryLabel}` : undefined}
+                  >
                     <Icon name="calendar" className="text-gray-400" />
-                    {scheduledCount ? `On ${scheduledCount} ${scheduledCount === 1 ? "day" : "days"}` : "Itinerary"}
+                    {itineraryLabel}
                   </Button>
                 }
               />
@@ -278,6 +288,9 @@ export default function Hotspot({ hotspot }: Props) {
     </>
   );
 }
+
+const formatDayLabel = (startDate: string | undefined, dayIndex: number) =>
+  startDate ? dayjs(startDate).add(dayIndex, "day").format("MMM D") : `Day ${dayIndex + 1}`;
 
 type ItineraryDayToggleProps = {
   day: Day;

--- a/frontend/modals/Hotspot.tsx
+++ b/frontend/modals/Hotspot.tsx
@@ -1,30 +1,23 @@
 import React from "react";
 import { Header, Body } from "components/Modal";
-import { Day, HotspotInput, Hotspot as HotspotT, Trip } from "@birdplan/shared";
+import { HotspotInput, Hotspot as HotspotT, Trip } from "@birdplan/shared";
 import { Button } from "components/ui/button";
 import toast from "react-hot-toast";
 import { useTrip } from "hooks/useTrip";
 import DirectionsButton from "components/DirectionsButton";
-import { isRegionEnglish, getMarkerColor, nanoId } from "lib/helpers";
+import { isRegionEnglish, getMarkerColor } from "lib/helpers";
 import RecentSpeciesList from "components/RecentSpeciesList";
 import HotspotStats from "components/HotspotStats";
 import RecentChecklistList from "components/RecentChecklistList";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "components/ui/tabs";
 import InputNotes from "components/InputNotes";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "components/ui/dropdown-menu";
 import KebabMenuTrigger from "components/KebabMenuTrigger";
 import HotspotTargets from "components/HotspotTargets";
 import HotspotFavs from "components/HotspotFavs";
+import ItineraryDays from "components/ItineraryDays";
 import Icon from "components/Icon";
 import { useLocation } from "react-router-dom";
-import dayjs from "dayjs";
-import { getTripDays } from "lib/itinerary";
 import useTripMutation from "hooks/useTripMutation";
 import useMutation from "hooks/useMutation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -152,16 +145,6 @@ export default function Hotspot({ hotspot }: Props) {
 
   const canTranslate = isSaved && canEdit && !isRegionEnglish(trip?.region || "");
 
-  const days = getTripDays(trip);
-  const dayIds = days.map((it) => it.id);
-  const scheduledDayIndexes = days.flatMap((day, index) =>
-    day.locations?.some((loc) => loc.locationId === id) ? [index] : []
-  );
-  const extraDayCount = scheduledDayIndexes.length - 1;
-  const itineraryLabel = scheduledDayIndexes.length
-    ? `${formatDayLabel(trip?.startDate, scheduledDayIndexes[0])}${extraDayCount > 0 ? ` +${extraDayCount}` : ""}`
-    : "Itinerary";
-
   return (
     <>
       <Header>{name}</Header>
@@ -200,34 +183,15 @@ export default function Hotspot({ hotspot }: Props) {
               {isSaved ? "Saved" : "Save"}
             </Button>
           )}
-          {canEdit && isSaved && !!days.length && (
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    variant="outline-white"
-                    size="sm"
-                    aria-label={scheduledDayIndexes.length ? `Itinerary: ${itineraryLabel}` : undefined}
-                  >
-                    <Icon name="calendar" className="text-gray-400" />
-                    {itineraryLabel}
-                  </Button>
-                }
-              />
-              <DropdownMenuContent align="start" className="min-w-[200px]">
-                {days.map((day, index) => (
-                  <ItineraryDayToggle
-                    key={day.id}
-                    day={day}
-                    dayIndex={index}
-                    dayIds={dayIds}
-                    hotspotId={id}
-                  />
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
           <DirectionsButton lat={lat} lng={lng} hotspotId={id} />
+          <Button
+            variant="outline-white"
+            size="sm"
+            href={`https://ebird.org/hotspot/${id}`}
+            target="_blank"
+          >
+            <img src="/ebird.png" width={48} />
+          </Button>
           <DropdownMenu>
             <KebabMenuTrigger />
             <DropdownMenuContent align="end" className="w-[170px]">
@@ -239,6 +203,7 @@ export default function Hotspot({ hotspot }: Props) {
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
+        {isSaved && <ItineraryDays locationId={id} type="hotspot" className="-mt-2 mb-6" />}
         <HotspotStats id={id} speciesTotal={hotspot.species} checklistsTotal={hotspot.checklists} />
         <HotspotFavs hotspotId={id} />
 
@@ -286,74 +251,5 @@ export default function Hotspot({ hotspot }: Props) {
         </Tabs>
       </Body>
     </>
-  );
-}
-
-const formatDayLabel = (startDate: string | undefined, dayIndex: number) =>
-  startDate ? dayjs(startDate).add(dayIndex, "day").format("MMM D") : `Day ${dayIndex + 1}`;
-
-type ItineraryDayToggleProps = {
-  day: Day;
-  dayIndex: number;
-  dayIds: string[];
-  hotspotId: string;
-};
-
-function ItineraryDayToggle({ day, dayIndex, dayIds, hotspotId }: ItineraryDayToggleProps) {
-  const { trip } = useTrip();
-  const entry = day.locations?.find((loc) => loc.locationId === hotspotId);
-  const date = trip?.startDate ? dayjs(trip.startDate).add(dayIndex, "day").format("ddd, MMM D") : "";
-
-  const addMutation = useTripMutation<
-    { type: "hotspot"; locationId: string; id: string; dayIds: string[] },
-    { itinerary: Day[] }
-  >({
-    url: `/trips/${trip?._id}/itinerary/${day.id}/add-location`,
-    method: "POST",
-    updateCache: (old, input) => ({
-      ...old,
-      itinerary: getTripDays(old).map((it) =>
-        it.id === day.id
-          ? {
-              ...it,
-              locations: [...(it.locations || []), { type: input.type, locationId: input.locationId, id: input.id }],
-            }
-          : it
-      ),
-    }),
-    reconcile: (old, response) => ({ ...old, itinerary: response.itinerary }),
-  });
-
-  const removeMutation = useTripMutation<{ id: string }>({
-    url: `/trips/${trip?._id}/itinerary/${day.id}/remove-location`,
-    method: "PATCH",
-    updateCache: (old, input) => ({
-      ...old,
-      itinerary: getTripDays(old).map((it) =>
-        it.id === day.id ? { ...it, locations: it.locations?.filter((loc) => loc.id !== input.id) || [] } : it
-      ),
-    }),
-  });
-
-  const onCheckedChange = (checked: boolean) => {
-    if (checked) {
-      addMutation.mutate({ type: "hotspot", locationId: hotspotId, id: nanoId(6), dayIds });
-    } else if (entry) {
-      removeMutation.mutate({ id: entry.id });
-    }
-  };
-
-  return (
-    <DropdownMenuCheckboxItem
-      checked={!!entry}
-      onCheckedChange={onCheckedChange}
-      closeOnClick={false}
-      disabled={addMutation.isPending || removeMutation.isPending}
-    >
-      <span className="truncate">
-        Day {dayIndex + 1}
-        {date && <span className="text-muted-foreground"> · {date}</span>}
-      </span>
-    </DropdownMenuCheckboxItem>
   );
 }

--- a/frontend/modals/Hotspot.tsx
+++ b/frontend/modals/Hotspot.tsx
@@ -218,14 +218,6 @@ export default function Hotspot({ hotspot }: Props) {
             </DropdownMenu>
           )}
           <DirectionsButton lat={lat} lng={lng} hotspotId={id} />
-          <Button
-            variant="outline-white"
-            size="sm"
-            href={`https://ebird.org/hotspot/${id}`}
-            target="_blank"
-          >
-            <img src="/ebird.png" width={48} />
-          </Button>
           <DropdownMenu>
             <KebabMenuTrigger />
             <DropdownMenuContent align="end" className="w-[170px]">

--- a/frontend/modals/Marker.tsx
+++ b/frontend/modals/Marker.tsx
@@ -18,6 +18,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "components/
 import KebabMenuTrigger from "components/KebabMenuTrigger";
 import { getGooglePlaceUrl } from "lib/helpers";
 import EmptyState from "components/EmptyState";
+import ItineraryDays from "components/ItineraryDays";
 
 type Props = {
   markerId?: string;
@@ -160,6 +161,7 @@ export default function Marker({ markerId, lat: defaultLat, lng: defaultLng }: P
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
+            <ItineraryDays locationId={marker.id} type="marker" className="mt-4 mb-4" />
             <InputNotes
               value={marker.notes}
               onBlur={(value) => saveNotesMutation.mutate({ notes: value })}

--- a/frontend/pages/[tripId]/itinerary.tsx
+++ b/frontend/pages/[tripId]/itinerary.tsx
@@ -12,16 +12,13 @@ import Icon from "components/Icon";
 import { Printer } from "lucide-react";
 import useTripMutation from "hooks/useTripMutation";
 import ItineraryDay from "components/ItineraryDay";
+import { getTripDays } from "lib/itinerary";
 
 export default function Itinerary() {
   const { trip, canEdit } = useTrip();
   const { close, modalId } = useModal();
   const isDateRange = !!(trip?.startDate && trip?.endDate);
-  const dayCount = isDateRange ? dayjs(trip!.endDate).diff(dayjs(trip!.startDate), "day") + 1 : 0;
-  const persistedDays = trip?.itinerary || [];
-  const renderDays = isDateRange
-    ? Array.from({ length: dayCount }, (_, i) => persistedDays[i] || { id: `${trip!._id}-d${i}`, locations: [] })
-    : persistedDays;
+  const renderDays = getTripDays(trip);
   const dayIds = renderDays.map((d) => d.id);
   const hasDays = renderDays.length > 0;
   const shouldDefaultEdit = !!(trip && !isDateRange) || !!(trip && !trip?.itinerary?.length);


### PR DESCRIPTION
Locations can currently only be scheduled from the itinerary page, and it can be hard to remember which hotspots are geographically close when you're on the itinerary page and can't see the map.

This PR adds a day picker to the hotspot modal, so when you find a hotspot on the map you can put it on a day without navigating away.

The trigger sits with Save / Directions / eBird, and reads "Itinerary" or "On 2 days" depending on state. Inside is a `DropdownMenuCheckboxItem` per day, labelled `Day 2 · Tue, Sep 8`. Checking schedules the hotspot, unchecking removes it — one control for both, which also means the menu doubles as an at-a-glance view of where the hotspot already sits, and the menu stays open so you can set several days in one go.

The control only appears for a saved hotspot on a trip that has dates. Unsaved hotspots are excluded because the itinerary references `trip.hotspots` by id, so scheduling one would render as "Unknown Location"; a trip with no date range has no days to offer.

Notes:

- Days are derived from the trip's date range rather than stored, so I pulled that derivation out of `pages/[tripId]/itinerary.tsx` into `getTripDays()` in `lib/itinerary.ts` and used it in both places. The modal needs it to build the virtual day ids, to send `dayIds` so the server can densify, and to apply the optimistic cache update against a day that may not be persisted yet.
- Verified against a trip with a date range and an **empty** `itinerary` array — the case where every day id is virtual. Adding to `<tripId>-d1` correctly densifies all three days server-side and lands the location on day 2; removing clears it.
- Both mutations go through `useTripMutation` with optimistic `updateCache` plus `reconcile` on the server's returned itinerary. Because the URL contains the day id, each day renders a small component with its own mutations rather than one mutation with a computed URL — happy to restructure if you'd rather see that done differently.