### PR TITLE
Species map trip dates frequency view

### DIFF
--- a/frontend/components/MapOverlay.tsx
+++ b/frontend/components/MapOverlay.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import { Card } from "components/ui/card";
 import { Button } from "components/ui/button";
-import { XIcon } from "lucide-react";
+import { ArrowLeftIcon, XIcon } from "lucide-react";
 import { useModal } from "stores/modals";
 import { cn } from "lib/utils";
 
 type Props = {
   onClose: () => void;
+  closeVariant?: "dismiss" | "back";
   className?: string;
   children: React.ReactNode;
   title: string;
 };
 
-export default function MapOverlay({ onClose, title, className, children }: Props) {
+export default function MapOverlay({ onClose, closeVariant = "dismiss", title, className, children }: Props) {
   const { modalId } = useModal();
 
   React.useEffect(() => {
@@ -35,8 +36,14 @@ export default function MapOverlay({ onClose, title, className, children }: Prop
           <h2 className="text-lg font-semibold">{title}</h2>
           <div className="text-xs text-muted-foreground mt-1.5">{children}</div>
         </div>
-        <Button variant="ghost" size="icon-lg" className="-mr-1 -mt-1 shrink-0" onClick={onClose} aria-label="Close">
-          <XIcon className="size-5" />
+        <Button
+          variant="ghost"
+          size="icon-lg"
+          className="-mr-1 -mt-1 shrink-0"
+          onClick={onClose}
+          aria-label={closeVariant === "back" ? "Back" : "Close"}
+        >
+          {closeVariant === "back" ? <ArrowLeftIcon className="size-5" /> : <XIcon className="size-5" />}
         </Button>
       </div>
     </Card>

--- a/frontend/components/Mapbox.tsx
+++ b/frontend/components/Mapbox.tsx
@@ -178,7 +178,7 @@ export default function Mapbox({
             <MarkerWithIcon
               icon="hotspot"
               color={marker.color}
-              className={marker.faded ? "opacity-40" : undefined}
+              className={marker.faded && marker.id !== selectedMarkerId ? "opacity-40" : undefined}
               highlight={marker.id === selectedMarkerId}
             />
           </Marker>

--- a/frontend/components/Mapbox.tsx
+++ b/frontend/components/Mapbox.tsx
@@ -3,7 +3,7 @@ import Map, { Marker, Source, Layer, GeolocateControl } from "react-map-gl";
 import { Marker as MarkerT } from "lib/types";
 import { Trip, CustomMarker } from "@birdplan/shared";
 import { MarkerIconT } from "lib/icons";
-import { markerColors, getLatLngFromBounds } from "lib/helpers";
+import { markerColors, getLatLngFromBounds, layerHasFrequency } from "lib/helpers";
 import MarkerWithIcon from "components/MarkerWithIcon";
 import clsx from "clsx";
 import { useModal } from "stores/modals";
@@ -92,14 +92,27 @@ export default function Mapbox({
     },
   };
 
+  const hasFrequencyData = layerHasFrequency(obsLayer);
+
   const obsLayerStyle = {
     id: "obs",
     type: "circle",
     paint: {
-      "circle-radius": isMobile ? 8 : 7,
-      "circle-stroke-width": 0.75,
-      "circle-stroke-color": "#555",
-      "circle-color": ["match", ["get", "isPersonal"], "true", "#555", "#ce0d02"],
+      "circle-radius": hasFrequencyData
+        ? ["match", ["get", "isSaved"], "true", isMobile ? 9 : 8, isMobile ? 7 : 6]
+        : isMobile
+          ? 8
+          : 7,
+      "circle-stroke-width": hasFrequencyData ? ["match", ["get", "isSaved"], "true", 2.5, 0.75] : 0.75,
+      "circle-stroke-color": hasFrequencyData ? ["match", ["get", "isSaved"], "true", "#1e3a8a", "#555"] : "#555",
+      "circle-color": hasFrequencyData
+        ? [
+            "case",
+            ["==", ["get", "hasFrequency"], "false"],
+            "#b8b8b8",
+            ["match", ["get", "colorIndex"], ...markerColors.flatMap((color, i) => [i, color]), markerColors[3]],
+          ]
+        : ["match", ["get", "isPersonal"], "true", "#555", "#ce0d02"],
     },
   };
 
@@ -214,13 +227,34 @@ export default function Mapbox({
           </Marker>
         )}
       </Map>
-      {obsLayer && (
+      {obsLayer && !hasFrequencyData && (
         <div className="flex absolute bottom-0 left-0 bg-white/90 py-1.5 pl-2 pr-3 text-xs items-center gap-2 z-10 rounded-tr-sm">
           <span className="flex items-center gap-1">
             <span className="w-2.5 h-2.5 rounded-full bg-[#555]" /> Personal Location
           </span>
           <span className="flex items-center gap-1">
             <span className="w-2.5 h-2.5 rounded-full bg-[#ce0d02]" /> Hotspot
+          </span>
+        </div>
+      )}
+      {obsLayer && hasFrequencyData && (
+        <div className="flex flex-wrap absolute bottom-0 left-0 bg-white/90 py-1.5 pl-2 pr-3 text-xs items-center gap-x-3 gap-y-1 z-10 rounded-tr-sm">
+          <span className="text-gray-500">Chance during trip dates:</span>
+          {[
+            [markerColors[3], "<15%"],
+            [markerColors[5], "15%"],
+            [markerColors[7], "30%"],
+            [markerColors[9], "50%+"],
+          ].map(([color, caption]) => (
+            <span key={caption} className="flex items-center gap-1">
+              <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} /> {caption}
+            </span>
+          ))}
+          <span className="flex items-center gap-1">
+            <span className="w-2.5 h-2.5 rounded-full bg-[#b8b8b8]" /> No data
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2.5 h-2.5 rounded-full border-2 border-[#1e3a8a] bg-transparent" /> Saved
           </span>
         </div>
       )}

--- a/frontend/components/Mapbox.tsx
+++ b/frontend/components/Mapbox.tsx
@@ -184,7 +184,7 @@ export default function Mapbox({
               handleHotspotClick(marker.id);
             }}
           >
-            <MarkerWithIcon icon="hotspot" highlight={marker.id === selectedMarkerId} />
+            <MarkerWithIcon icon="hotspot" color={marker.color} highlight={marker.id === selectedMarkerId} />
           </Marker>
         ))}
         {customMarkers?.map((marker) => (

--- a/frontend/components/Mapbox.tsx
+++ b/frontend/components/Mapbox.tsx
@@ -98,20 +98,11 @@ export default function Mapbox({
     id: "obs",
     type: "circle",
     paint: {
-      "circle-radius": hasFrequencyData
-        ? ["match", ["get", "isSaved"], "true", isMobile ? 9 : 8, isMobile ? 7 : 6]
-        : isMobile
-          ? 8
-          : 7,
-      "circle-stroke-width": hasFrequencyData ? ["match", ["get", "isSaved"], "true", 2.5, 0.75] : 0.75,
-      "circle-stroke-color": hasFrequencyData ? ["match", ["get", "isSaved"], "true", "#1e3a8a", "#555"] : "#555",
+      "circle-radius": hasFrequencyData ? (isMobile ? 7 : 6) : isMobile ? 8 : 7,
+      "circle-stroke-width": 0.75,
+      "circle-stroke-color": "#555",
       "circle-color": hasFrequencyData
-        ? [
-            "case",
-            ["==", ["get", "hasFrequency"], "false"],
-            "#b8b8b8",
-            ["match", ["get", "colorIndex"], ...markerColors.flatMap((color, i) => [i, color]), markerColors[3]],
-          ]
+        ? ["match", ["get", "colorIndex"], ...markerColors.flatMap((color, i) => [i, color]), markerColors[3]]
         : ["match", ["get", "isPersonal"], "true", "#555", "#ce0d02"],
     },
   };
@@ -250,12 +241,6 @@ export default function Mapbox({
               <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} /> {caption}
             </span>
           ))}
-          <span className="flex items-center gap-1">
-            <span className="w-2.5 h-2.5 rounded-full bg-[#b8b8b8]" /> No data
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="w-2.5 h-2.5 rounded-full border-2 border-[#1e3a8a] bg-transparent" /> Saved
-          </span>
         </div>
       )}
       <div className="absolute bottom-0 left-16 right-16 h-4 sm:hidden">

--- a/frontend/components/Mapbox.tsx
+++ b/frontend/components/Mapbox.tsx
@@ -241,10 +241,10 @@ export default function Mapbox({
         <div className="flex flex-wrap absolute bottom-0 left-0 bg-white/90 py-1.5 pl-2 pr-3 text-xs items-center gap-x-3 gap-y-1 z-10 rounded-tr-sm">
           <span className="text-gray-500">Chance during trip dates:</span>
           {[
-            [markerColors[3], "<15%"],
-            [markerColors[5], "15%"],
-            [markerColors[7], "30%"],
-            [markerColors[9], "50%+"],
+            [markerColors[3], "<5%"],
+            [markerColors[5], "10%"],
+            [markerColors[7], "40%"],
+            [markerColors[9], "80%+"],
           ].map(([color, caption]) => (
             <span key={caption} className="flex items-center gap-1">
               <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} /> {caption}

--- a/frontend/components/Mapbox.tsx
+++ b/frontend/components/Mapbox.tsx
@@ -175,7 +175,12 @@ export default function Mapbox({
               handleHotspotClick(marker.id);
             }}
           >
-            <MarkerWithIcon icon="hotspot" color={marker.color} highlight={marker.id === selectedMarkerId} />
+            <MarkerWithIcon
+              icon="hotspot"
+              color={marker.color}
+              className={marker.faded ? "opacity-40" : undefined}
+              highlight={marker.id === selectedMarkerId}
+            />
           </Marker>
         ))}
         {customMarkers?.map((marker) => (

--- a/frontend/components/MarkerWithIcon.tsx
+++ b/frontend/components/MarkerWithIcon.tsx
@@ -11,7 +11,7 @@ type Props = {
   highlight?: boolean;
 };
 
-export default function MarkerWithIcon({ icon, darkIcon, showStroke = true, className, highlight }: Props) {
+export default function MarkerWithIcon({ icon, darkIcon, color, showStroke = true, className, highlight }: Props) {
   const iconData = markerIcons[icon];
   if (!iconData) return null;
   return (
@@ -22,7 +22,7 @@ export default function MarkerWithIcon({ icon, darkIcon, showStroke = true, clas
         className
       )}
       style={{
-        backgroundColor: iconData.color,
+        backgroundColor: color ?? iconData.color,
       }}
     >
       {highlight && (

--- a/frontend/components/SpeciesHero.tsx
+++ b/frontend/components/SpeciesHero.tsx
@@ -142,7 +142,7 @@ export default function SpeciesHero({ name, scientificName, code, starred, mutua
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={onShowMap}>
                   <Map className="text-gray-500" />
-                  Recent Reports Map
+                  Show on Map
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   render={<a href={`https://ebird.org/species/${code}`} target="_blank" rel="noopener noreferrer" />}

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -24,7 +24,6 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const { trip, selectedSpecies, setSelectedSpecies } = useTrip();
   const { open, modalId } = useModal();
   const [mode, setMode] = React.useState<MapMode>("trip");
-  const [showInfo, setShowInfo] = React.useState(true);
   const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
   const setShowPersonalLocations = useMapPreferences((state) => state.setShowPersonalLocations);
   const savedHotspotsOnly = useMapPreferences((state) => state.savedHotspotsOnly);
@@ -60,7 +59,7 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
       id: it.id,
       lat: it.lat,
       lng: it.lng,
-      color: mode === "trip" && frequency != null ? markerColors[frequencyColorIndex(frequency)] : undefined,
+      color: mode === "trip" ? markerColors[frequency == null ? 0 : frequencyColorIndex(frequency)] : undefined,
     };
   });
 
@@ -84,20 +83,6 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
 
   return (
     <div className="absolute inset-0 z-10 flex flex-col" onClick={onOutsideClick}>
-      {showInfo && (
-        <MapOverlay onClose={() => setShowInfo(false)} title={selectedSpecies.name}>
-          {subtitle}{" "}
-          <Button
-            className="underline"
-            variant="link"
-            size="sm"
-            href={`https://ebird.org/map/${selectedSpecies.code}?env.minX=${trip?.bounds?.minX}&env.minY=${trip?.bounds?.minY}&env.maxX=${trip?.bounds?.maxX}&env.maxY=${trip?.bounds?.maxY}`}
-            target="_blank"
-          >
-            View on eBird
-          </Button>
-        </MapOverlay>
-      )}
       <div className="w-full grow relative">
         {trip?.bounds && (
           <MapBox
@@ -108,10 +93,24 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
             bounds={trip.bounds}
           />
         )}
-        <div className="absolute top-4 right-4 sm:left-4 sm:right-auto z-10 flex flex-col items-end sm:items-start gap-3">
-          <MapButton onClick={() => setSelectedSpecies(undefined)} tooltip="Close map">
-            <Icon name="xMark" />
-          </MapButton>
+        <div className="absolute top-3 left-3 right-3 sm:right-auto sm:w-[26rem] z-10 flex flex-col items-start gap-3">
+          <MapOverlay
+            onClose={() => setSelectedSpecies(undefined)}
+            closeVariant="back"
+            title={selectedSpecies.name}
+            className="relative left-0 top-0 w-full max-w-none translate-x-0"
+          >
+            {subtitle}{" "}
+            <Button
+              className="underline"
+              variant="link"
+              size="sm"
+              href={`https://ebird.org/map/${selectedSpecies.code}?env.minX=${trip?.bounds?.minX}&env.minY=${trip?.bounds?.minY}&env.maxX=${trip?.bounds?.maxX}&env.maxY=${trip?.bounds?.maxY}`}
+              target="_blank"
+            >
+              View on eBird
+            </Button>
+          </MapOverlay>
           <SegmentedControl<MapMode>
             value={mode}
             onChange={setMode}
@@ -130,7 +129,11 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
           <MapButton
             onClick={() => setShowPersonalLocations(!showPersonalLocations)}
             tooltip={
-              personalDisabled ? "Personal locations only appear in recent sightings" : "Hide personal locations"
+              personalDisabled
+                ? "Personal locations are only in recent sightings"
+                : showPersonalLocations
+                  ? "Hide personal locations"
+                  : "Show personal locations"
             }
             active={showPersonalLocations && !personalDisabled}
             disabled={personalDisabled}

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -9,7 +9,7 @@ import { useTrip } from "hooks/useTrip";
 import { useModal } from "stores/modals";
 import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
 import useSpeciesHotspotRankings from "hooks/useSpeciesHotspotRankings";
-import { buildFrequencyLayer, frequencyColorIndex, markerColors } from "lib/helpers";
+import { buildFrequencyLayer, filterOutPersonal, frequencyColorIndex, markerColors } from "lib/helpers";
 import MarkerWithIcon from "components/MarkerWithIcon";
 import { useMapPreferences } from "stores/mapPreferences";
 import { Button } from "components/ui/button";
@@ -22,7 +22,7 @@ type Props = {
 
 export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const { trip, selectedSpecies, setSelectedSpecies } = useTrip();
-  const { open, modalId } = useModal();
+  const { open } = useModal();
   const [mode, setMode] = React.useState<MapMode>("trip");
   const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
   const setShowPersonalLocations = useMapPreferences((state) => state.setShowPersonalLocations);
@@ -34,21 +34,13 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
     setSavedHotspotsOnly(false);
   }
 
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !modalId) setSelectedSpecies(undefined);
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [modalId, setSelectedSpecies]);
-
   const savedHotspots = trip?.hotspots ?? [];
   const savedIds = new Set(savedHotspots.map((it) => it.id));
 
   const { obs, obsLayer } = useFetchSpeciesObs({ region: trip?.region, code: selectedSpecies?.code });
   const regionHotspots = useSpeciesHotspotRankings(selectedSpecies?.code);
   const savedRanked = useSpeciesHotspotRankings(
-    selectedSpecies?.code,
+    mode === "trip" ? selectedSpecies?.code : undefined,
     savedHotspots.map((it) => it.id)
   );
 
@@ -56,7 +48,8 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
 
   const savedFrequency = new Map(savedRanked.map((it) => [it.id, it.frequency]));
   const regionLayer = buildFrequencyLayer(regionHotspots, savedIds);
-  const layer = savedHotspotsOnly ? null : mode === "trip" ? regionLayer : obsLayer;
+  const recentLayer = showPersonalLocations ? obsLayer : filterOutPersonal(obsLayer);
+  const layer = savedHotspotsOnly ? null : mode === "trip" ? regionLayer : recentLayer;
 
   const markers = savedHotspots.map((it) => {
     const frequency = savedFrequency.get(it.id);

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -3,11 +3,14 @@ import toast from "react-hot-toast";
 import MapBox from "components/Mapbox";
 import MapOverlay from "components/MapOverlay";
 import SegmentedControl from "components/SegmentedControl";
+import MapButton from "components/MapButton";
+import Icon from "components/Icon";
 import { useTrip } from "hooks/useTrip";
 import { useModal } from "stores/modals";
 import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
 import useSpeciesHotspotRankings from "hooks/useSpeciesHotspotRankings";
 import { buildFrequencyLayer } from "lib/helpers";
+import { useMapPreferences } from "stores/mapPreferences";
 import { Button } from "components/ui/button";
 
 type MapMode = "trip" | "recent";
@@ -20,6 +23,8 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const { trip, selectedSpecies, setSelectedSpecies } = useTrip();
   const { open } = useModal();
   const [mode, setMode] = React.useState<MapMode>("trip");
+  const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
+  const setShowPersonalLocations = useMapPreferences((state) => state.setShowPersonalLocations);
 
   const { obs, obsLayer } = useFetchSpeciesObs({ region: trip?.region, code: selectedSpecies?.code });
   const { hotspots } = useSpeciesHotspotRankings(selectedSpecies?.code);
@@ -61,7 +66,7 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
       </MapOverlay>
       <div className="w-full grow relative">
         {trip?.bounds && <MapBox key={trip._id} onHotspotClick={handleClick} obsLayer={layer} bounds={trip.bounds} />}
-        <div className="absolute top-4 right-4 z-10">
+        <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-3">
           <SegmentedControl<MapMode>
             value={mode}
             onChange={setMode}
@@ -70,6 +75,15 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
               { value: "recent", label: "Recent sightings" },
             ]}
           />
+          {mode === "recent" && (
+            <MapButton
+              onClick={() => setShowPersonalLocations(!showPersonalLocations)}
+              tooltip={showPersonalLocations ? "Hide personal locations" : "Show personal locations"}
+              active={showPersonalLocations}
+            >
+              <Icon name="user" />
+            </MapButton>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -9,7 +9,7 @@ import { useTrip } from "hooks/useTrip";
 import { useModal } from "stores/modals";
 import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
 import useSpeciesHotspotRankings from "hooks/useSpeciesHotspotRankings";
-import { buildFrequencyLayer, filterOutPersonal, frequencyColorIndex, markerColors } from "lib/helpers";
+import { buildFrequencyLayer, filterLayer, frequencyColorIndex, markerColors } from "lib/helpers";
 import MarkerWithIcon from "components/MarkerWithIcon";
 import { useMapPreferences } from "stores/mapPreferences";
 import { Button } from "components/ui/button";
@@ -48,7 +48,10 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
 
   const savedFrequency = new Map(savedRanked.map((it) => [it.id, it.frequency]));
   const regionLayer = buildFrequencyLayer(regionHotspots, savedIds);
-  const recentLayer = showPersonalLocations ? obsLayer : filterOutPersonal(obsLayer);
+  const recentLayer = filterLayer(
+    obsLayer,
+    (it) => !savedIds.has(it.id) && (showPersonalLocations || it.isPersonal !== "true")
+  );
   const layer = savedHotspotsOnly ? null : mode === "trip" ? regionLayer : recentLayer;
 
   const reportedIds = new Set(obs.map((it) => it.id));

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -26,8 +26,13 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const [mode, setMode] = React.useState<MapMode>("trip");
   const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
   const setShowPersonalLocations = useMapPreferences((state) => state.setShowPersonalLocations);
-  const savedHotspotsOnly = useMapPreferences((state) => state.savedHotspotsOnly);
-  const setSavedHotspotsOnly = useMapPreferences((state) => state.setSavedHotspotsOnly);
+  const [savedHotspotsOnly, setSavedHotspotsOnly] = React.useState(false);
+  const [prevCode, setPrevCode] = React.useState(selectedSpecies?.code);
+
+  if (selectedSpecies?.code !== prevCode) {
+    setPrevCode(selectedSpecies?.code);
+    setSavedHotspotsOnly(false);
+  }
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -21,10 +21,19 @@ type Props = {
 
 export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const { trip, selectedSpecies, setSelectedSpecies } = useTrip();
-  const { open } = useModal();
+  const { open, modalId } = useModal();
   const [mode, setMode] = React.useState<MapMode>("trip");
+  const [showInfo, setShowInfo] = React.useState(true);
   const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
   const setShowPersonalLocations = useMapPreferences((state) => state.setShowPersonalLocations);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !modalId) setSelectedSpecies(undefined);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [modalId, setSelectedSpecies]);
 
   const { obs, obsLayer } = useFetchSpeciesObs({ region: trip?.region, code: selectedSpecies?.code });
   const { hotspots } = useSpeciesHotspotRankings(selectedSpecies?.code);
@@ -52,21 +61,26 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
 
   return (
     <div className="absolute inset-0 z-10 flex flex-col" onClick={onOutsideClick}>
-      <MapOverlay onClose={() => setSelectedSpecies(undefined)} title={selectedSpecies.name}>
-        {subtitle}{" "}
-        <Button
-          className="underline"
-          variant="link"
-          size="sm"
-          href={`https://ebird.org/map/${selectedSpecies.code}?env.minX=${trip?.bounds?.minX}&env.minY=${trip?.bounds?.minY}&env.maxX=${trip?.bounds?.maxX}&env.maxY=${trip?.bounds?.maxY}`}
-          target="_blank"
-        >
-          View on eBird
-        </Button>
-      </MapOverlay>
+      {showInfo && (
+        <MapOverlay onClose={() => setShowInfo(false)} title={selectedSpecies.name}>
+          {subtitle}{" "}
+          <Button
+            className="underline"
+            variant="link"
+            size="sm"
+            href={`https://ebird.org/map/${selectedSpecies.code}?env.minX=${trip?.bounds?.minX}&env.minY=${trip?.bounds?.minY}&env.maxX=${trip?.bounds?.maxX}&env.maxY=${trip?.bounds?.maxY}`}
+            target="_blank"
+          >
+            View on eBird
+          </Button>
+        </MapOverlay>
+      )}
       <div className="w-full grow relative">
         {trip?.bounds && <MapBox key={trip._id} onHotspotClick={handleClick} obsLayer={layer} bounds={trip.bounds} />}
-        <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-3">
+        <div className="absolute top-4 right-4 sm:left-4 sm:right-auto z-10 flex flex-col items-end sm:items-start gap-3">
+          <MapButton onClick={() => setSelectedSpecies(undefined)} tooltip="Close map">
+            <Icon name="xMark" />
+          </MapButton>
           <SegmentedControl<MapMode>
             value={mode}
             onChange={setMode}

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -1,23 +1,54 @@
 import React from "react";
+import toast from "react-hot-toast";
 import MapBox from "components/Mapbox";
 import MapOverlay from "components/MapOverlay";
+import SegmentedControl from "components/SegmentedControl";
 import { useTrip } from "hooks/useTrip";
+import { useModal } from "stores/modals";
+import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
+import useSpeciesHotspotRankings from "hooks/useSpeciesHotspotRankings";
+import { buildFrequencyLayer } from "lib/helpers";
 import { Button } from "components/ui/button";
+
+type MapMode = "trip" | "recent";
 
 type Props = {
   onOutsideClick: (e: React.MouseEvent<HTMLElement>) => void;
-  onHotspotClick: (id: string) => void;
-  obsLayer: React.ComponentProps<typeof MapBox>["obsLayer"];
 };
 
-export default function SpeciesMapOverlay({ onOutsideClick, onHotspotClick, obsLayer }: Props) {
+export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const { trip, selectedSpecies, setSelectedSpecies } = useTrip();
+  const { open } = useModal();
+  const [mode, setMode] = React.useState<MapMode>("trip");
+
+  const { obs, obsLayer } = useFetchSpeciesObs({ region: trip?.region, code: selectedSpecies?.code });
+  const { hotspots } = useSpeciesHotspotRankings(selectedSpecies?.code);
+
   if (!selectedSpecies) return null;
+
+  const savedIds = new Set(trip?.hotspots.map((it) => it.id) ?? []);
+  const layer = mode === "trip" ? buildFrequencyLayer(hotspots, savedIds) : obsLayer;
+
+  const subtitle =
+    mode === "trip"
+      ? "Hotspots shaded by how often the species is reported during your trip dates."
+      : "Reports from the last 30 days.";
+
+  const handleClick = (id: string) => {
+    const observation = obs.find((it) => it.id === id);
+    const target = trip?.hotspots.find((it) => it.id === id) || observation || hotspots.find((it) => it.id === id);
+    if (!target) return toast.error("Location not found");
+    open(observation?.isPersonal ? "personalLocation" : "hotspot", {
+      hotspot: target,
+      speciesCode: selectedSpecies.code,
+      speciesName: selectedSpecies.name,
+    });
+  };
 
   return (
     <div className="absolute inset-0 z-10 flex flex-col" onClick={onOutsideClick}>
       <MapOverlay onClose={() => setSelectedSpecies(undefined)} title={selectedSpecies.name}>
-        Showing reports over the last 30 days.{" "}
+        {subtitle}{" "}
         <Button
           className="underline"
           variant="link"
@@ -29,9 +60,17 @@ export default function SpeciesMapOverlay({ onOutsideClick, onHotspotClick, obsL
         </Button>
       </MapOverlay>
       <div className="w-full grow relative">
-        {trip?.bounds && (
-          <MapBox key={trip._id} onHotspotClick={onHotspotClick} obsLayer={obsLayer} bounds={trip.bounds} />
-        )}
+        {trip?.bounds && <MapBox key={trip._id} onHotspotClick={handleClick} obsLayer={layer} bounds={trip.bounds} />}
+        <div className="absolute top-4 right-4 z-10">
+          <SegmentedControl<MapMode>
+            value={mode}
+            onChange={setMode}
+            options={[
+              { value: "trip", label: "Trip dates" },
+              { value: "recent", label: "Recent sightings" },
+            ]}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -51,13 +51,17 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const recentLayer = showPersonalLocations ? obsLayer : filterOutPersonal(obsLayer);
   const layer = savedHotspotsOnly ? null : mode === "trip" ? regionLayer : recentLayer;
 
+  const reportedIds = new Set(obs.map((it) => it.id));
+
   const markers = savedHotspots.map((it) => {
     const frequency = savedFrequency.get(it.id);
+    const hasDataForMode = mode === "trip" ? frequency != null : reportedIds.has(it.id);
     return {
       id: it.id,
       lat: it.lat,
       lng: it.lng,
       color: mode === "trip" ? markerColors[frequency == null ? 0 : frequencyColorIndex(frequency)] : undefined,
+      faded: !hasDataForMode,
     };
   });
 

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -9,7 +9,7 @@ import { useTrip } from "hooks/useTrip";
 import { useModal } from "stores/modals";
 import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
 import useSpeciesHotspotRankings from "hooks/useSpeciesHotspotRankings";
-import { buildFrequencyLayer } from "lib/helpers";
+import { buildFrequencyLayer, filterLayerToSaved } from "lib/helpers";
 import { useMapPreferences } from "stores/mapPreferences";
 import { Button } from "components/ui/button";
 
@@ -26,6 +26,8 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   const [showInfo, setShowInfo] = React.useState(true);
   const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
   const setShowPersonalLocations = useMapPreferences((state) => state.setShowPersonalLocations);
+  const savedHotspotsOnly = useMapPreferences((state) => state.savedHotspotsOnly);
+  const setSavedHotspotsOnly = useMapPreferences((state) => state.setSavedHotspotsOnly);
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -41,7 +43,8 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
   if (!selectedSpecies) return null;
 
   const savedIds = new Set(trip?.hotspots.map((it) => it.id) ?? []);
-  const layer = mode === "trip" ? buildFrequencyLayer(hotspots, savedIds) : obsLayer;
+  const fullLayer = mode === "trip" ? buildFrequencyLayer(hotspots, savedIds) : obsLayer;
+  const layer = savedHotspotsOnly ? filterLayerToSaved(fullLayer, savedIds) : fullLayer;
 
   const subtitle =
     mode === "trip"
@@ -89,7 +92,14 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
               { value: "recent", label: "Recent sightings" },
             ]}
           />
-          {mode === "recent" && (
+          <MapButton
+            onClick={() => setSavedHotspotsOnly(!savedHotspotsOnly)}
+            tooltip={savedHotspotsOnly ? "Show all hotspots" : "Show only saved hotspots"}
+            active={savedHotspotsOnly}
+          >
+            <Icon name={savedHotspotsOnly ? "star" : "starOutline"} />
+          </MapButton>
+          {mode === "recent" && !savedHotspotsOnly && (
             <MapButton
               onClick={() => setShowPersonalLocations(!showPersonalLocations)}
               tooltip={showPersonalLocations ? "Hide personal locations" : "Show personal locations"}

--- a/frontend/components/SpeciesMapOverlay.tsx
+++ b/frontend/components/SpeciesMapOverlay.tsx
@@ -9,7 +9,8 @@ import { useTrip } from "hooks/useTrip";
 import { useModal } from "stores/modals";
 import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
 import useSpeciesHotspotRankings from "hooks/useSpeciesHotspotRankings";
-import { buildFrequencyLayer, filterLayerToSaved } from "lib/helpers";
+import { buildFrequencyLayer, frequencyColorIndex, markerColors } from "lib/helpers";
+import MarkerWithIcon from "components/MarkerWithIcon";
 import { useMapPreferences } from "stores/mapPreferences";
 import { Button } from "components/ui/button";
 
@@ -37,14 +38,33 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [modalId, setSelectedSpecies]);
 
+  const savedHotspots = trip?.hotspots ?? [];
+  const savedIds = new Set(savedHotspots.map((it) => it.id));
+
   const { obs, obsLayer } = useFetchSpeciesObs({ region: trip?.region, code: selectedSpecies?.code });
-  const { hotspots } = useSpeciesHotspotRankings(selectedSpecies?.code);
+  const regionHotspots = useSpeciesHotspotRankings(selectedSpecies?.code);
+  const savedRanked = useSpeciesHotspotRankings(
+    selectedSpecies?.code,
+    savedHotspots.map((it) => it.id)
+  );
 
   if (!selectedSpecies) return null;
 
-  const savedIds = new Set(trip?.hotspots.map((it) => it.id) ?? []);
-  const fullLayer = mode === "trip" ? buildFrequencyLayer(hotspots, savedIds) : obsLayer;
-  const layer = savedHotspotsOnly ? filterLayerToSaved(fullLayer, savedIds) : fullLayer;
+  const savedFrequency = new Map(savedRanked.map((it) => [it.id, it.frequency]));
+  const regionLayer = buildFrequencyLayer(regionHotspots, savedIds);
+  const layer = savedHotspotsOnly ? null : mode === "trip" ? regionLayer : obsLayer;
+
+  const markers = savedHotspots.map((it) => {
+    const frequency = savedFrequency.get(it.id);
+    return {
+      id: it.id,
+      lat: it.lat,
+      lng: it.lng,
+      color: mode === "trip" && frequency != null ? markerColors[frequencyColorIndex(frequency)] : undefined,
+    };
+  });
+
+  const personalDisabled = mode === "trip" || savedHotspotsOnly;
 
   const subtitle =
     mode === "trip"
@@ -53,7 +73,7 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
 
   const handleClick = (id: string) => {
     const observation = obs.find((it) => it.id === id);
-    const target = trip?.hotspots.find((it) => it.id === id) || observation || hotspots.find((it) => it.id === id);
+    const target = savedHotspots.find((it) => it.id === id) || observation || regionHotspots.find((it) => it.id === id);
     if (!target) return toast.error("Location not found");
     open(observation?.isPersonal ? "personalLocation" : "hotspot", {
       hotspot: target,
@@ -79,7 +99,15 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
         </MapOverlay>
       )}
       <div className="w-full grow relative">
-        {trip?.bounds && <MapBox key={trip._id} onHotspotClick={handleClick} obsLayer={layer} bounds={trip.bounds} />}
+        {trip?.bounds && (
+          <MapBox
+            key={trip._id}
+            onHotspotClick={handleClick}
+            markers={markers}
+            obsLayer={layer}
+            bounds={trip.bounds}
+          />
+        )}
         <div className="absolute top-4 right-4 sm:left-4 sm:right-auto z-10 flex flex-col items-end sm:items-start gap-3">
           <MapButton onClick={() => setSelectedSpecies(undefined)} tooltip="Close map">
             <Icon name="xMark" />
@@ -97,17 +125,18 @@ export default function SpeciesMapOverlay({ onOutsideClick }: Props) {
             tooltip={savedHotspotsOnly ? "Show all hotspots" : "Show only saved hotspots"}
             active={savedHotspotsOnly}
           >
-            <Icon name={savedHotspotsOnly ? "star" : "starOutline"} />
+            <MarkerWithIcon icon="hotspot" showStroke={false} className="scale-[0.7]" />
           </MapButton>
-          {mode === "recent" && !savedHotspotsOnly && (
-            <MapButton
-              onClick={() => setShowPersonalLocations(!showPersonalLocations)}
-              tooltip={showPersonalLocations ? "Hide personal locations" : "Show personal locations"}
-              active={showPersonalLocations}
-            >
-              <Icon name="user" />
-            </MapButton>
-          )}
+          <MapButton
+            onClick={() => setShowPersonalLocations(!showPersonalLocations)}
+            tooltip={
+              personalDisabled ? "Personal locations only appear in recent sightings" : "Hide personal locations"
+            }
+            active={showPersonalLocations && !personalDisabled}
+            disabled={personalDisabled}
+          >
+            <Icon name="user" />
+          </MapButton>
         </div>
       </div>
     </div>

--- a/frontend/hooks/useCloseOnOutsideClick.ts
+++ b/frontend/hooks/useCloseOnOutsideClick.ts
@@ -9,7 +9,8 @@ export default function useCloseOnOutsideClick() {
       !target.closest("button") &&
       !target.closest("a") &&
       !target.closest('[role="button"]') &&
-      !target.closest(".mapboxgl-canvas")
+      !target.closest(".mapboxgl-canvas") &&
+      !target.closest(".mapboxgl-marker")
     ) {
       close();
     }

--- a/frontend/hooks/useFetchSpeciesObs.ts
+++ b/frontend/hooks/useFetchSpeciesObs.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { EBIRD_BASE_URL } from "lib/config";
+import { useMapPreferences } from "stores/mapPreferences";
 
 type Obs = {
   id: string;
@@ -16,6 +17,8 @@ type Props = {
 };
 
 export default function useFetchSpeciesObs({ region, code }: Props) {
+  const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
+
   const { data } = useQuery<Obs[]>({
     queryKey: [`${EBIRD_BASE_URL}/data/obs/${region}/recent/${code}`, { back: 30, includeProvisional: true }],
     enabled: !!region && !!code,
@@ -29,14 +32,16 @@ export default function useFetchSpeciesObs({ region, code }: Props) {
   });
 
   const obs: Obs[] =
-    data?.map(({ lat, lng, locId, locationPrivate, locName, obsDt }: any) => ({
-      lat,
-      lng,
-      id: locId,
-      name: locName,
-      isPersonal: locationPrivate,
-      obsDt,
-    })) || [];
+    data
+      ?.filter(({ locationPrivate }: any) => showPersonalLocations || !locationPrivate)
+      .map(({ lat, lng, locId, locationPrivate, locName, obsDt }: any) => ({
+        lat,
+        lng,
+        id: locId,
+        name: locName,
+        isPersonal: locationPrivate,
+        obsDt,
+      })) || [];
 
   const hasFetched = obs.length > 0;
 

--- a/frontend/hooks/useFetchSpeciesObs.ts
+++ b/frontend/hooks/useFetchSpeciesObs.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { EBIRD_BASE_URL } from "lib/config";
-import { useMapPreferences } from "stores/mapPreferences";
 
 type Obs = {
   id: string;
@@ -17,8 +16,6 @@ type Props = {
 };
 
 export default function useFetchSpeciesObs({ region, code }: Props) {
-  const showPersonalLocations = useMapPreferences((state) => state.showPersonalLocations);
-
   const { data } = useQuery<Obs[]>({
     queryKey: [`${EBIRD_BASE_URL}/data/obs/${region}/recent/${code}`, { back: 30, includeProvisional: true }],
     enabled: !!region && !!code,
@@ -32,16 +29,14 @@ export default function useFetchSpeciesObs({ region, code }: Props) {
   });
 
   const obs: Obs[] =
-    data
-      ?.filter(({ locationPrivate }: any) => showPersonalLocations || !locationPrivate)
-      .map(({ lat, lng, locId, locationPrivate, locName, obsDt }: any) => ({
-        lat,
-        lng,
-        id: locId,
-        name: locName,
-        isPersonal: locationPrivate,
-        obsDt,
-      })) || [];
+    data?.map(({ lat, lng, locId, locationPrivate, locName, obsDt }: any) => ({
+      lat,
+      lng,
+      id: locId,
+      name: locName,
+      isPersonal: locationPrivate,
+      obsDt,
+    })) || [];
 
   const hasFetched = obs.length > 0;
 

--- a/frontend/hooks/useSpeciesHotspotRankings.ts
+++ b/frontend/hooks/useSpeciesHotspotRankings.ts
@@ -20,7 +20,7 @@ export default function useSpeciesHotspotRankings(code?: string, locationIds?: s
         body: JSON.stringify({
           ...(locationIds ? { locationIds } : { region: trip?.region, limit: HOTSPOT_LIMIT }),
           months,
-          sortBy: "frequency",
+          sortBy: "best",
         }),
       });
       if (!res.ok) throw new Error("Failed to fetch hotspot rankings");

--- a/frontend/hooks/useSpeciesHotspotRankings.ts
+++ b/frontend/hooks/useSpeciesHotspotRankings.ts
@@ -6,25 +6,30 @@ import type { OpenBirdingHotspotRankingResponse } from "@birdplan/shared";
 
 const HOTSPOT_LIMIT = 500;
 
-export default function useSpeciesHotspotRankings(code?: string) {
+export default function useSpeciesHotspotRankings(code?: string, locationIds?: string[]) {
   const { trip } = useTrip();
   const months = trip ? getMonthRange(trip.startMonth, trip.endMonth) : [];
+  const scope = locationIds ? locationIds.join(",") : trip?.region;
 
-  const { data, isLoading } = useQuery<OpenBirdingHotspotRankingResponse>({
-    queryKey: ["openbirding-trip-hotspots", code, trip?.region, months.join(",")],
+  const { data } = useQuery<OpenBirdingHotspotRankingResponse>({
+    queryKey: ["openbirding-trip-hotspots", code, scope, months.join(",")],
     queryFn: async () => {
       const res = await fetch(`${OPENBIRDING_API_URL}/api/v1/hotspots/species/${code}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ region: trip?.region, limit: HOTSPOT_LIMIT, months, sortBy: "frequency" }),
+        body: JSON.stringify({
+          ...(locationIds ? { locationIds } : { region: trip?.region, limit: HOTSPOT_LIMIT }),
+          months,
+          sortBy: "frequency",
+        }),
       });
       if (!res.ok) throw new Error("Failed to fetch hotspot rankings");
       return res.json();
     },
-    enabled: !!code && !!OPENBIRDING_API_URL && !!trip?.region,
+    enabled: !!code && !!OPENBIRDING_API_URL && (locationIds ? locationIds.length > 0 : !!trip?.region),
     staleTime: 24 * 60 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
-  return { hotspots: data?.items ?? [], isLoading };
+  return data?.items ?? [];
 }

--- a/frontend/hooks/useSpeciesHotspotRankings.ts
+++ b/frontend/hooks/useSpeciesHotspotRankings.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { OPENBIRDING_API_URL } from "lib/config";
+import { getMonthRange } from "lib/targets";
+import { useTrip } from "hooks/useTrip";
+import type { OpenBirdingHotspotRankingResponse } from "@birdplan/shared";
+
+const HOTSPOT_LIMIT = 500;
+
+export default function useSpeciesHotspotRankings(code?: string) {
+  const { trip } = useTrip();
+  const months = trip ? getMonthRange(trip.startMonth, trip.endMonth) : [];
+
+  const { data, isLoading } = useQuery<OpenBirdingHotspotRankingResponse>({
+    queryKey: ["openbirding-trip-hotspots", code, trip?.region, months.join(",")],
+    queryFn: async () => {
+      const res = await fetch(`${OPENBIRDING_API_URL}/api/v1/hotspots/species/${code}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ region: trip?.region, limit: HOTSPOT_LIMIT, months, sortBy: "frequency" }),
+      });
+      if (!res.ok) throw new Error("Failed to fetch hotspot rankings");
+      return res.json();
+    },
+    enabled: !!code && !!OPENBIRDING_API_URL && !!trip?.region,
+    staleTime: 24 * 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  return { hotspots: data?.items ?? [], isLoading };
+}

--- a/frontend/lib/helpers.ts
+++ b/frontend/lib/helpers.ts
@@ -126,13 +126,10 @@ export const getMarkerColorIndex = (count: number) => {
   return markerColors.indexOf(color);
 };
 
-export const filterLayerToSaved = (layer: any, savedIds: Set<string>) =>
-  layer && { ...layer, features: layer.features.filter((it: any) => savedIds.has(it.properties?.id)) };
-
 export const layerHasFrequency = (layer?: any) =>
   !!layer?.features?.some((it: any) => it.properties?.hasFrequency === "true");
 
-const frequencyColorIndex = (frequency: number) => {
+export const frequencyColorIndex = (frequency: number) => {
   if (frequency >= 50) return 9;
   if (frequency >= 40) return 8;
   if (frequency >= 30) return 7;
@@ -146,16 +143,16 @@ export const buildFrequencyLayer = (
   hotspots: { id: string; lat: number; lng: number; frequency: number }[],
   savedIds: Set<string>
 ): GeoJSON.FeatureCollection | null => {
-  if (hotspots.length === 0) return null;
+  const unsaved = hotspots.filter((it) => !savedIds.has(it.id));
+  if (unsaved.length === 0) return null;
   return {
     type: "FeatureCollection",
-    features: hotspots.map((hotspot) => ({
+    features: unsaved.map((hotspot) => ({
       type: "Feature",
       geometry: { type: "Point", coordinates: [hotspot.lng, hotspot.lat] },
       properties: {
         id: hotspot.id,
         hasFrequency: "true",
-        isSaved: savedIds.has(hotspot.id) ? "true" : "false",
         colorIndex: frequencyColorIndex(hotspot.frequency),
       },
     })),

--- a/frontend/lib/helpers.ts
+++ b/frontend/lib/helpers.ts
@@ -126,8 +126,8 @@ export const getMarkerColorIndex = (count: number) => {
   return markerColors.indexOf(color);
 };
 
-export const filterOutPersonal = (layer: any) =>
-  layer && { ...layer, features: layer.features.filter((it: any) => it.properties?.isPersonal !== "true") };
+export const filterLayer = (layer: any, keep: (properties: any) => boolean) =>
+  layer && { ...layer, features: layer.features.filter((it: any) => keep(it.properties ?? {})) };
 
 export const layerHasFrequency = (layer?: any) =>
   !!layer?.features?.some((it: any) => it.properties?.hasFrequency === "true");

--- a/frontend/lib/helpers.ts
+++ b/frontend/lib/helpers.ts
@@ -126,6 +126,9 @@ export const getMarkerColorIndex = (count: number) => {
   return markerColors.indexOf(color);
 };
 
+export const filterOutPersonal = (layer: any) =>
+  layer && { ...layer, features: layer.features.filter((it: any) => it.properties?.isPersonal !== "true") };
+
 export const layerHasFrequency = (layer?: any) =>
   !!layer?.features?.some((it: any) => it.properties?.hasFrequency === "true");
 

--- a/frontend/lib/helpers.ts
+++ b/frontend/lib/helpers.ts
@@ -126,6 +126,39 @@ export const getMarkerColorIndex = (count: number) => {
   return markerColors.indexOf(color);
 };
 
+export const layerHasFrequency = (layer?: any) =>
+  !!layer?.features?.some((it: any) => it.properties?.hasFrequency === "true");
+
+const frequencyColorIndex = (frequency: number) => {
+  if (frequency >= 50) return 9;
+  if (frequency >= 40) return 8;
+  if (frequency >= 30) return 7;
+  if (frequency >= 20) return 6;
+  if (frequency >= 15) return 5;
+  if (frequency >= 10) return 4;
+  return 3;
+};
+
+export const buildFrequencyLayer = (
+  hotspots: { id: string; lat: number; lng: number; frequency: number }[],
+  savedIds: Set<string>
+): GeoJSON.FeatureCollection | null => {
+  if (hotspots.length === 0) return null;
+  return {
+    type: "FeatureCollection",
+    features: hotspots.map((hotspot) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [hotspot.lng, hotspot.lat] },
+      properties: {
+        id: hotspot.id,
+        hasFrequency: "true",
+        isSaved: savedIds.has(hotspot.id) ? "true" : "false",
+        colorIndex: frequencyColorIndex(hotspot.frequency),
+      },
+    })),
+  };
+};
+
 export const buildHotspotsLayer = (
   hotspots: eBirdHotspot[],
   savedHotspots: Hotspot[]

--- a/frontend/lib/helpers.ts
+++ b/frontend/lib/helpers.ts
@@ -130,12 +130,12 @@ export const layerHasFrequency = (layer?: any) =>
   !!layer?.features?.some((it: any) => it.properties?.hasFrequency === "true");
 
 export const frequencyColorIndex = (frequency: number) => {
-  if (frequency >= 50) return 9;
-  if (frequency >= 40) return 8;
-  if (frequency >= 30) return 7;
+  if (frequency >= 80) return 9;
+  if (frequency >= 60) return 8;
+  if (frequency >= 40) return 7;
   if (frequency >= 20) return 6;
-  if (frequency >= 15) return 5;
-  if (frequency >= 10) return 4;
+  if (frequency >= 10) return 5;
+  if (frequency >= 5) return 4;
   return 3;
 };
 

--- a/frontend/lib/helpers.ts
+++ b/frontend/lib/helpers.ts
@@ -126,6 +126,9 @@ export const getMarkerColorIndex = (count: number) => {
   return markerColors.indexOf(color);
 };
 
+export const filterLayerToSaved = (layer: any, savedIds: Set<string>) =>
+  layer && { ...layer, features: layer.features.filter((it: any) => savedIds.has(it.properties?.id)) };
+
 export const layerHasFrequency = (layer?: any) =>
   !!layer?.features?.some((it: any) => it.properties?.hasFrequency === "true");
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -6,6 +6,7 @@ export type Marker = {
   id: string;
   shade?: number;
   color?: string;
+  faded?: boolean;
 };
 
 export type CustomMarker = {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -5,6 +5,7 @@ export type Marker = {
   lng: number;
   id: string;
   shade?: number;
+  color?: string;
 };
 
 export type CustomMarker = {

--- a/frontend/modals/Hotspot.tsx
+++ b/frontend/modals/Hotspot.tsx
@@ -129,11 +129,11 @@ export default function Hotspot({ hotspot }: Props) {
 
   const hasSpecies = !!modalSpecies && location.pathname.includes("targets");
   React.useEffect(() => {
-    if (hasSpecies) {
+    if (isSaved) {
+      setHalo(undefined);
+    } else if (hasSpecies) {
       setHalo({ lat, lng, color: "#ce0d02" });
-    } else if (isSaved) {
-      setSelectedMarkerId(id);
-    } else if (!isSaved) {
+    } else {
       setHalo({ lat, lng, color: getMarkerColor(species || 0) });
     }
     setSelectedMarkerId(id);

--- a/frontend/pages/[tripId]/targets.tsx
+++ b/frontend/pages/[tripId]/targets.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import { useModal } from "stores/modals";
-import useFetchSpeciesObs from "hooks/useFetchSpeciesObs";
 import useCloseOnOutsideClick from "hooks/useCloseOnOutsideClick";
-import toast from "react-hot-toast";
 import { useTrip } from "hooks/useTrip";
 import SpeciesMapOverlay from "components/SpeciesMapOverlay";
 import { Card } from "components/ui/card";
@@ -27,13 +24,8 @@ import { Download } from "lucide-react";
 const PAGE_SIZE = 100;
 
 export default function TripTargets() {
-  const { open } = useModal();
-  const { trip, selectedSpecies, canEdit } = useTrip();
+  const { trip, canEdit } = useTrip();
   const handleContainerClick = useCloseOnOutsideClick();
-  const { obs, obsLayer } = useFetchSpeciesObs({
-    region: trip?.region,
-    code: selectedSpecies?.code,
-  });
 
   // Filter options
   const [search, setSearch] = React.useState("");
@@ -93,23 +85,6 @@ export default function TripTargets() {
   );
 
   const truncatedTargets = filteredTargets?.slice(0, showCount);
-
-  const obsClick = (id: string) => {
-    const observation = obs.find((it) => it.id === id);
-    if (!observation) return toast.error("Observation not found");
-    if (observation.isPersonal) {
-      open("personalLocation", {
-        hotspot: observation,
-        speciesCode: selectedSpecies?.code,
-        speciesName: selectedSpecies?.name,
-      });
-    } else {
-      open("hotspot", {
-        hotspot: observation,
-        speciesName: selectedSpecies?.name,
-      });
-    }
-  };
 
   return (
     <>
@@ -270,7 +245,7 @@ export default function TripTargets() {
           </div>
         </div>
       </div>
-      <SpeciesMapOverlay onOutsideClick={handleContainerClick} onHotspotClick={obsClick} obsLayer={obsLayer} />
+      <SpeciesMapOverlay onOutsideClick={handleContainerClick} />
     </>
   );
 }

--- a/frontend/pages/[tripId]/targets/[speciesCode].tsx
+++ b/frontend/pages/[tripId]/targets/[speciesCode].tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useParams } from "react-router-dom";
-import toast from "react-hot-toast";
 import TextareaAutosize from "react-textarea-autosize";
 import { useQuery } from "@tanstack/react-query";
 import { useDebounceCallback } from "usehooks-ts";
@@ -62,7 +61,7 @@ export default function SpeciesDetail() {
     }),
   });
 
-  const { obs, obsLayer } = useFetchSpeciesObs({ region: trip?.region, code: speciesCode });
+  const { obs } = useFetchSpeciesObs({ region: trip?.region, code: speciesCode });
   const regionCode = trip?.region.split(",")[0] || "";
 
   const lastSeenByLocId: Record<string, string> = {};
@@ -202,16 +201,6 @@ export default function SpeciesDetail() {
     setSelectedSpecies({ code: speciesCode, name: speciesName || speciesCode });
   };
 
-  const obsClick = (id: string) => {
-    const observation = obs.find((it) => it.id === id);
-    if (!observation) return toast.error("Observation not found");
-    open(observation.isPersonal ? "personalLocation" : "hotspot", {
-      hotspot: observation,
-      speciesCode,
-      speciesName,
-    });
-  };
-
   return (
     <>
       {trip && speciesName && <title>{`${speciesName} | ${trip.name} | BirdPlan.app`}</title>}
@@ -306,7 +295,7 @@ export default function SpeciesDetail() {
           </div>
         </div>
       </div>
-      <SpeciesMapOverlay onOutsideClick={handleContainerClick} onHotspotClick={obsClick} obsLayer={obsLayer} />
+      <SpeciesMapOverlay onOutsideClick={handleContainerClick} />
     </>
   );
 }

--- a/frontend/stores/mapPreferences.ts
+++ b/frontend/stores/mapPreferences.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type MapPreferencesState = {
+  showPersonalLocations: boolean;
+  setShowPersonalLocations: (showPersonalLocations: boolean) => void;
+};
+
+export const useMapPreferences = create<MapPreferencesState>()(
+  persist(
+    (set) => ({
+      showPersonalLocations: true,
+      setShowPersonalLocations: (showPersonalLocations) => set({ showPersonalLocations }),
+    }),
+    {
+      name: "map-preferences",
+      storage: createJSONStorage(() => localStorage),
+      partialize: ({ showPersonalLocations }) => ({ showPersonalLocations }),
+    }
+  )
+);

--- a/frontend/stores/mapPreferences.ts
+++ b/frontend/stores/mapPreferences.ts
@@ -3,23 +3,19 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 type MapPreferencesState = {
   showPersonalLocations: boolean;
-  savedHotspotsOnly: boolean;
   setShowPersonalLocations: (showPersonalLocations: boolean) => void;
-  setSavedHotspotsOnly: (savedHotspotsOnly: boolean) => void;
 };
 
 export const useMapPreferences = create<MapPreferencesState>()(
   persist(
     (set) => ({
       showPersonalLocations: true,
-      savedHotspotsOnly: false,
       setShowPersonalLocations: (showPersonalLocations) => set({ showPersonalLocations }),
-      setSavedHotspotsOnly: (savedHotspotsOnly) => set({ savedHotspotsOnly }),
     }),
     {
       name: "map-preferences",
       storage: createJSONStorage(() => localStorage),
-      partialize: ({ showPersonalLocations, savedHotspotsOnly }) => ({ showPersonalLocations, savedHotspotsOnly }),
+      partialize: ({ showPersonalLocations }) => ({ showPersonalLocations }),
     }
   )
 );

--- a/frontend/stores/mapPreferences.ts
+++ b/frontend/stores/mapPreferences.ts
@@ -3,19 +3,23 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 type MapPreferencesState = {
   showPersonalLocations: boolean;
+  savedHotspotsOnly: boolean;
   setShowPersonalLocations: (showPersonalLocations: boolean) => void;
+  setSavedHotspotsOnly: (savedHotspotsOnly: boolean) => void;
 };
 
 export const useMapPreferences = create<MapPreferencesState>()(
   persist(
     (set) => ({
       showPersonalLocations: true,
+      savedHotspotsOnly: false,
       setShowPersonalLocations: (showPersonalLocations) => set({ showPersonalLocations }),
+      setSavedHotspotsOnly: (savedHotspotsOnly) => set({ savedHotspotsOnly }),
     }),
     {
       name: "map-preferences",
       storage: createJSONStorage(() => localStorage),
-      partialize: ({ showPersonalLocations }) => ({ showPersonalLocations }),
+      partialize: ({ showPersonalLocations, savedHotspotsOnly }) => ({ showPersonalLocations, savedHotspotsOnly }),
     }
   )
 );


### PR DESCRIPTION
Situation: The species map plots eBird reports from the last 30 days ("where has this been seen lately"), not "where will I find it on my trip". Out of season, those diverge, and the recent view isn't useful for trip planning. A reliable hotspot during the trip dates shows nothing if nobody has seen the species lately.

This PR tries to address this. It: 
1) Adds a "trip dates" mode to the target species view, plotting hotspots ranked and colored by species sighting frequency.
2) In both modes, highlights saved hotspots with the trip map star marker. The marker is colored by frequency in the trip dates mode, and faded in either mode where there is no observation data for the saved hotspot.
3) Adds map toggles: saved-hotspots-only and a "hide personal locations" mirroring the trip map
4) Moves the species name card/ebird link/map description, and changes the X to a back arrow to clarify function between "back" and "close card"


Example species highlighting this situation: it hasn't been seen lately, but is relatively common during a November trip:

<img width="2422" height="434" alt="Screenshot 2026-09-01 at 12 17 51 AM" src="https://github.com/user-attachments/assets/a9873cf2-f165-47e6-a624-90c8ac3831c7" />

Menu item now reads "show on map" instead of specifying "recent"

<img width="2220" height="774" alt="Screenshot 2026-09-01 at 12 17 59 AM" src="https://github.com/user-attachments/assets/93a00449-b90c-4e0f-9e0f-090fc52c535c" />

Map now has selector for recent vs. trip dates. Hotspots on trip dates are colored by frequency. Species name/map description card is moved to side, and the X/close button changed to a back arrow. X was misleading, and made me think it would close the card, not leave the map.

<img width="2426" height="1870" alt="Screenshot 2026-09-01 at 12 18 21 AM" src="https://github.com/user-attachments/assets/aa0d025f-0788-43f8-8346-d8d665d7fe41" />

Added a "show only saved hotspots"/"show all hotspots" toggle button to simplify view for trip planning:

<img width="2258" height="1674" alt="Screenshot 2026-09-01 at 12 18 58 AM" src="https://github.com/user-attachments/assets/f45c8bae-2402-4634-a74a-60aef4c26083" />


No sightings in the last 30 days for this species, so a blank map except for faded saved hotspots:

<img width="3774" height="1882" alt="Screenshot 2026-09-01 at 12 32 45 AM" src="https://github.com/user-attachments/assets/85489673-3ce2-43e2-a351-bccc497f53ef" />

Recent sightings for a species that has observations in the last 30 days- same as present, except saved hotspots marked:
<img width="2336" height="1872" alt="Screenshot 2026-09-01 at 12 35 57 AM" src="https://github.com/user-attachments/assets/7319383b-f5ab-4923-9a1c-f5116c985c53" />

